### PR TITLE
修复Sublime Plugin，URL中文编码问题

### DIFF
--- a/Mdnsearch.py
+++ b/Mdnsearch.py
@@ -9,9 +9,16 @@ import sublime_plugin
 import subprocess
 import webbrowser
 
+try:
+    # python2
+    from urllib import quote
+except ImportError:
+    # python3
+    from urllib.parse import quote
+
 
 def SearchFor(text):
-    url = 'http://unbug.github.io/codelf/#' + text.replace(' ', '%20')
+    url = 'http://unbug.github.io/codelf/#' + quote(text)
     webbrowser.open_new_tab(url)
 
 
@@ -40,4 +47,3 @@ class CodelfSelectionCommand(sublime_plugin.TextCommand):
 
             text = self.view.substr(selection)
             SearchFor(text)
-


### PR DESCRIPTION
当search中文时，出现UnicodeEncodeError
Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 818, in run_
    return self.run(edit)
  File "/Users/username/Library/Application Support/Sublime Text 3/Packages/Codelf/Mdnsearch.py", line 40, in run
    SearchFor(text)
  File "/Users/username/Library/Application Support/Sublime Text 3/Packages/Codelf/Mdnsearch.py", line 13, in SearchFor
    webbrowser.open_new_tab(url)
  File "./python3.3/webbrowser.py", line 70, in open_new_tab
  File "./python3.3/webbrowser.py", line 62, in open
  File "./python3.3/webbrowser.py", line 635, in open
UnicodeEncodeError: 'ascii' codec can't encode characters in position 46-54: ordinal not in range(128)
