### PR TITLE
docs: update Chrome Web Store URL to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Plugins
 
 Apps
 =================
-[Codelf Chrome App](https://chrome.google.com/webstore/detail/codelf-best-github-stars/jnmjaglhmmcplekpfnblniiammmdpaan)
+[Codelf Chrome App](https://chromewebstore.google.com/detail/codelf-best-github-stars/jnmjaglhmmcplekpfnblniiammmdpaan)
 
   
 Find me


### PR DESCRIPTION
## Summary

- Updated 1 Chrome Web Store URL in README.md from `chrome.google.com/webstore` to `chromewebstore.google.com`
- Google migrated the Chrome Web Store to a new domain; the old URLs now redirect

## Details

The Chrome Web Store moved to `chromewebstore.google.com`. The old `chrome.google.com/webstore` URLs still redirect, but it's better to link directly to the canonical domain.